### PR TITLE
feat: allow rows without headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,13 @@ class MyWidget extends StatelessWidget {
 }
 ```
 
+### Selectable Rows, Highlighted Rows
+
+On Desktop and web, rows are by default highlighted when the mouse cursor is hovered over them. Rows can be selected by passing `selectedRowIndex`. Highlighted and selected styles can be configured in `DataGridThemeData`.
+
 ### Frozen Headers
 
 By default column headers are frozen, this means that row content will scroll underneath them.
 
-By default row headers are frozen, however this can be disabled using `hasRowHeader` boolean. When disabled, all the row offers additional functionality such as selection and hover states. Selection and hover states may be considered in the future for rows containing frozen headers.
+By default row headers are frozen, however this can be disabled using `hasRowHeader` boolean.
 

--- a/README.md
+++ b/README.md
@@ -42,5 +42,11 @@ class MyWidget extends StatelessWidget {
     );
   }
 }
-
 ```
+
+### Frozen Headers
+
+By default column headers are frozen, this means that row content will scroll underneath them.
+
+By default row headers are frozen, however this can be disabled using `hasRowHeader` boolean. When disabled, all the row offers additional functionality such as selection and hover states. Selection and hover states may be considered in the future for rows containing frozen headers.
+

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -48,7 +48,7 @@ class Grid extends StatefulWidget {
     /// Whether each row has a header (which contents can scroll behind)
     this.hasRowHeader = true,
 
-    /// The current selected row index (only considered when [hasRowHeader] is `false`)
+    /// The current selected row index
     this.selectedRowIndex,
   })  : assert(
           rows.every((element) => element.children.length == columns.length),
@@ -89,7 +89,7 @@ class Grid extends StatefulWidget {
   /// Whether each row has a header (which contents can scroll behind)
   final bool hasRowHeader;
 
-  /// The current selected row index (only considered when [hasRowHeader] is `false`)
+  /// The current selected row index
   final int? selectedRowIndex;
 
   @override
@@ -104,6 +104,11 @@ class _GridState extends State<Grid> {
   final verticalControllers = SyncScrollControllerGroup();
   late final SyncScrollControllerGroup horizontalControllers;
   List<int> indices = [];
+  // a row is hovered if either the header is hovered or remaining rows are hovered
+  int? _hoveringRowIndexHeader;
+  int? _hoveringRowIndexRows;
+  int? get _hoveringRowIndex =>
+      _hoveringRowIndexHeader ?? _hoveringRowIndexRows;
 
   @override
   void initState() {
@@ -312,6 +317,15 @@ class _GridState extends State<Grid> {
                   width: widget.columns.first.width,
                   scrollController: rowHeaderController,
                   separatorBuilder: widget.horizontalSeparatorBuilder,
+                  hoveringRowIndex: _hoveringRowIndex,
+                  onHoverIndex: (index) => setState(
+                    () => _hoveringRowIndexHeader = index,
+                  ),
+                  highlightDecoration:
+                      widget.dataGridThemeData.rowHighlightDecoration,
+                  selectedRowIndex: widget.selectedRowIndex,
+                  selectedDecoration:
+                      widget.dataGridThemeData.rowSelectedDecoration,
                 ),
               GridRows(
                 indices: indices,
@@ -322,6 +336,10 @@ class _GridState extends State<Grid> {
                 rowsControllerY: rowsControllerY,
                 rowsControllerX: rowsControllerX,
                 showHeader: !widget.hasRowHeader,
+                hoveringRowIndex: _hoveringRowIndex,
+                onHoverIndex: (index) => setState(
+                  () => _hoveringRowIndexRows = index,
+                ),
                 highlightDecoration:
                     widget.dataGridThemeData.rowHighlightDecoration,
                 selectedRowIndex: widget.selectedRowIndex,

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -47,6 +47,12 @@ class Grid extends StatefulWidget {
 
     /// An optional decoration when a row is highlighted
     this.rowHighlightDecoration,
+
+    /// The current selected row index
+    this.selectedRowIndex,
+
+    /// An optional decoration when a row is selected
+    this.rowSelectedDecoration,
   })  : assert(
           rows.every((element) => element.children.length == columns.length),
         ),
@@ -88,6 +94,12 @@ class Grid extends StatefulWidget {
 
   /// An optional decoration when a row is highlighted
   final BoxDecoration? rowHighlightDecoration;
+
+  /// The current selected row index
+  final int? selectedRowIndex;
+
+  /// An optional decoration when a row is selected
+  final BoxDecoration? rowSelectedDecoration;
 
   @override
   State<Grid> createState() => _GridState();
@@ -319,6 +331,7 @@ class _GridState extends State<Grid> {
                 rowsControllerX: rowsControllerX,
                 showHeader: !widget.hasRowHeader,
                 highlightDecoration: widget.rowHighlightDecoration,
+                selectedRowIndex: widget.selectedRowIndex,
               ),
             ],
           ),

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -300,6 +300,7 @@ class _GridState extends State<Grid> {
           indices: indices,
           scrollController: columnHeaderController,
           sortingIconSettings: widget.dataGridThemeData.sortingIconSettings,
+          hasRowHeader: widget.hasRowHeader,
         ),
         SizedBox(
           width: calculateColumnWidths(indices)

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -2,9 +2,12 @@ library data_grid;
 
 import 'dart:math';
 
-import 'package:flutter/material.dart';
 import 'package:data_grid/src/components.dart';
+import 'package:data_grid/src/data_grid_theme.dart';
+import 'package:flutter/material.dart';
 import 'package:sync_scroll_controller/sync_scroll_controller.dart';
+
+export 'package:data_grid/src/data_grid_theme.dart';
 
 /// The [Grid]
 class Grid extends StatefulWidget {
@@ -40,19 +43,13 @@ class Grid extends StatefulWidget {
     Widget Function(BuildContext, int)? horizontalSeparatorBuilder,
 
     /// Settings for sorting icons
-    this.sortingIconSettings = const SortingIconSettings(),
+    this.dataGridThemeData = const DataGridThemeData(),
 
     /// Whether each row has a header (which contents can scroll behind)
     this.hasRowHeader = true,
 
-    /// An optional decoration when a row is highlighted
-    this.rowHighlightDecoration,
-
     /// The current selected row index
     this.selectedRowIndex,
-
-    /// An optional decoration when a row is selected
-    this.rowSelectedDecoration,
   })  : assert(
           rows.every((element) => element.children.length == columns.length),
         ),
@@ -87,19 +84,13 @@ class Grid extends StatefulWidget {
   final ScrollPhysics? physics;
 
   /// Settings for sorting icons
-  final SortingIconSettings sortingIconSettings;
+  final DataGridThemeData dataGridThemeData;
 
   /// Whether each row has a header (which contents can scroll behind)
   final bool hasRowHeader;
 
-  /// An optional decoration when a row is highlighted
-  final BoxDecoration? rowHighlightDecoration;
-
   /// The current selected row index
   final int? selectedRowIndex;
-
-  /// An optional decoration when a row is selected
-  final BoxDecoration? rowSelectedDecoration;
 
   @override
   State<Grid> createState() => _GridState();
@@ -238,8 +229,9 @@ class _GridState extends State<Grid> {
   ) {
     assert(column._autoFitColumnData != null);
 
-    final sortIconWidth = widget.sortingIconSettings.size;
-    final sortIconPadding = widget.sortingIconSettings.padding.horizontal;
+    final sortIconWidth = widget.dataGridThemeData.sortingIconSettings.size;
+    final sortIconPadding =
+        widget.dataGridThemeData.sortingIconSettings.padding.horizontal;
 
     double width = _textWidth(
           column._autoFitColumnData!.text,
@@ -302,7 +294,7 @@ class _GridState extends State<Grid> {
           columns: widget.columns,
           indices: indices,
           scrollController: columnHeaderController,
-          sortingIconSettings: widget.sortingIconSettings,
+          sortingIconSettings: widget.dataGridThemeData.sortingIconSettings,
         ),
         SizedBox(
           width: calculateColumnWidths(indices)
@@ -330,8 +322,11 @@ class _GridState extends State<Grid> {
                 rowsControllerY: rowsControllerY,
                 rowsControllerX: rowsControllerX,
                 showHeader: !widget.hasRowHeader,
-                highlightDecoration: widget.rowHighlightDecoration,
+                highlightDecoration:
+                    widget.dataGridThemeData.rowHighlightDecoration,
                 selectedRowIndex: widget.selectedRowIndex,
+                selectedDecoration:
+                    widget.dataGridThemeData.rowSelectedDecoration,
               ),
             ],
           ),
@@ -675,41 +670,4 @@ enum SortingState {
         return SortingState.descending;
     }
   }
-}
-
-class SortingIconSettings {
-  final IconData ascending;
-  final IconData descending;
-  final double size;
-  final Color? color;
-  final EdgeInsets padding;
-
-  const SortingIconSettings({
-    this.ascending = Icons.arrow_upward_rounded,
-    this.descending = Icons.arrow_downward_rounded,
-    this.size = 20,
-    this.color,
-    this.padding = const EdgeInsets.symmetric(horizontal: 4.0),
-  });
-
-  @override
-  bool operator ==(Object other) {
-    if (identical(this, other)) return true;
-
-    return other is SortingIconSettings &&
-        other.ascending == ascending &&
-        other.descending == descending &&
-        other.size == size &&
-        other.color == color &&
-        other.padding == padding;
-  }
-
-  @override
-  int get hashCode => Object.hash(
-        ascending,
-        descending,
-        size,
-        color,
-        padding,
-      );
 }

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -48,7 +48,7 @@ class Grid extends StatefulWidget {
     /// Whether each row has a header (which contents can scroll behind)
     this.hasRowHeader = true,
 
-    /// The current selected row index
+    /// The current selected row index (only considered when [hasRowHeader] is `false`)
     this.selectedRowIndex,
   })  : assert(
           rows.every((element) => element.children.length == columns.length),
@@ -89,7 +89,7 @@ class Grid extends StatefulWidget {
   /// Whether each row has a header (which contents can scroll behind)
   final bool hasRowHeader;
 
-  /// The current selected row index
+  /// The current selected row index (only considered when [hasRowHeader] is `false`)
   final int? selectedRowIndex;
 
   @override

--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -41,6 +41,12 @@ class Grid extends StatefulWidget {
 
     /// Settings for sorting icons
     this.sortingIconSettings = const SortingIconSettings(),
+
+    /// Whether each row has a header (which contents can scroll behind)
+    this.hasRowHeader = true,
+
+    /// An optional decoration when a row is highlighted
+    this.rowHighlightDecoration,
   })  : assert(
           rows.every((element) => element.children.length == columns.length),
         ),
@@ -76,6 +82,12 @@ class Grid extends StatefulWidget {
 
   /// Settings for sorting icons
   final SortingIconSettings sortingIconSettings;
+
+  /// Whether each row has a header (which contents can scroll behind)
+  final bool hasRowHeader;
+
+  /// An optional decoration when a row is highlighted
+  final BoxDecoration? rowHighlightDecoration;
 
   @override
   State<Grid> createState() => _GridState();
@@ -289,13 +301,14 @@ class _GridState extends State<Grid> {
           child: Row(
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: [
-              GridRowHeader(
-                physics: widget.physics,
-                rows: widget.rows,
-                width: widget.columns.first.width,
-                scrollController: rowHeaderController,
-                separatorBuilder: widget.horizontalSeparatorBuilder,
-              ),
+              if (widget.hasRowHeader)
+                GridRowHeader(
+                  physics: widget.physics,
+                  rows: widget.rows,
+                  width: widget.columns.first.width,
+                  scrollController: rowHeaderController,
+                  separatorBuilder: widget.horizontalSeparatorBuilder,
+                ),
               GridRows(
                 indices: indices,
                 physics: widget.physics,
@@ -304,6 +317,8 @@ class _GridState extends State<Grid> {
                 horizontalSeparatorBuilder: widget.horizontalSeparatorBuilder,
                 rowsControllerY: rowsControllerY,
                 rowsControllerX: rowsControllerX,
+                showHeader: !widget.hasRowHeader,
+                highlightDecoration: widget.rowHighlightDecoration,
               ),
             ],
           ),

--- a/lib/src/components.dart
+++ b/lib/src/components.dart
@@ -148,6 +148,7 @@ class GridColumnHeader extends StatelessWidget {
     required this.physics,
     required this.indices,
     required this.sortingIconSettings,
+    required this.hasRowHeader,
   }) : super(key: key);
 
   final List<GridColumn> columns;
@@ -155,6 +156,7 @@ class GridColumnHeader extends StatelessWidget {
   final ScrollPhysics? physics;
   final List<int> indices;
   final SortingIconSettings sortingIconSettings;
+  final bool hasRowHeader;
 
   @override
   Widget build(BuildContext context) {
@@ -163,19 +165,21 @@ class GridColumnHeader extends StatelessWidget {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         children: [
-          GridColumnHeaderCell(
-            sortColumn: () => sortByColumn(indices.first),
-            column: columns[indices.first],
-            sortingIconSettings: sortingIconSettings,
-          ),
+          if (hasRowHeader)
+            GridColumnHeaderCell(
+              sortColumn: () => sortByColumn(indices.first),
+              column: columns[indices.first],
+              sortingIconSettings: sortingIconSettings,
+            ),
           Expanded(
             child: ListView.builder(
                 physics: physics,
                 controller: scrollController,
                 scrollDirection: Axis.horizontal,
-                itemCount: indices.length - 1,
+                itemCount: hasRowHeader ? indices.length - 1 : indices.length,
                 itemBuilder: (context, columnIndex) {
-                  int index = indices[columnIndex + 1];
+                  int index =
+                      indices[hasRowHeader ? columnIndex + 1 : columnIndex];
                   return GridColumnHeaderCell(
                     sortColumn: () => sortByColumn(index),
                     column: columns[index],

--- a/lib/src/components.dart
+++ b/lib/src/components.dart
@@ -267,18 +267,19 @@ class _GridRowItemState extends State<_GridRowItem> {
   }
 
   BoxDecoration? _getDecoration() {
-    if (widget.isSelected) {
-      return widget.selectedDecoration ??
-          BoxDecoration(
-            color: Theme.of(context).primaryColor,
-          );
-    } else if (_isHovering) {
-      return widget.highlightDecoration ??
-          BoxDecoration(
-            color: Theme.of(context).splashColor,
-          );
-    } else {
-      return null;
+    if (widget.showHeader) {
+      if (widget.isSelected) {
+        return widget.selectedDecoration ??
+            BoxDecoration(
+              color: Theme.of(context).primaryColor,
+            );
+      } else if (_isHovering) {
+        return widget.highlightDecoration ??
+            BoxDecoration(
+              color: Theme.of(context).splashColor,
+            );
+      }
     }
+    return null;
   }
 }

--- a/lib/src/components.dart
+++ b/lib/src/components.dart
@@ -151,6 +151,8 @@ class GridRows extends StatelessWidget {
     required this.indices,
     required this.showHeader,
     this.highlightDecoration,
+    this.selectedRowIndex,
+    this.selectedDecoration,
   }) : super(key: key);
 
   final List<GridRow> rows;
@@ -161,6 +163,8 @@ class GridRows extends StatelessWidget {
   final List<int> indices;
   final bool showHeader;
   final BoxDecoration? highlightDecoration;
+  final int? selectedRowIndex;
+  final BoxDecoration? selectedDecoration;
 
   @override
   Widget build(BuildContext context) {
@@ -186,6 +190,8 @@ class GridRows extends StatelessWidget {
               indices: indices,
               showHeader: showHeader,
               highlightDecoration: highlightDecoration,
+              isSelected: selectedRowIndex == rowIndex,
+              selectedDecoration: selectedDecoration,
             ),
           ),
         ),
@@ -201,6 +207,8 @@ class _GridRowItem extends StatefulWidget {
     required this.indices,
     required this.showHeader,
     this.highlightDecoration,
+    this.isSelected = false,
+    this.selectedDecoration,
     Key? key,
   }) : super(key: key);
 
@@ -209,6 +217,8 @@ class _GridRowItem extends StatefulWidget {
   final List<int> indices;
   final bool showHeader;
   final BoxDecoration? highlightDecoration;
+  final bool isSelected;
+  final BoxDecoration? selectedDecoration;
 
   @override
   State<_GridRowItem> createState() => _GridRowItemState();
@@ -230,12 +240,7 @@ class _GridRowItemState extends State<_GridRowItem> {
         onEnter: (_) => setState(() => _isHovering = true),
         onExit: (_) => setState(() => _isHovering = false),
         child: Container(
-          decoration: _isHovering
-              ? widget.highlightDecoration ??
-                  BoxDecoration(
-                    color: Theme.of(context).splashColor,
-                  )
-              : null,
+          decoration: _getDecoration(),
           child: Row(
             children: [
               for (int i = widget.showHeader ? 0 : 1;
@@ -259,5 +264,21 @@ class _GridRowItemState extends State<_GridRowItem> {
         ),
       ),
     );
+  }
+
+  BoxDecoration? _getDecoration() {
+    if (widget.isSelected) {
+      return widget.selectedDecoration ??
+          BoxDecoration(
+            color: Theme.of(context).primaryColor,
+          );
+    } else if (_isHovering) {
+      return widget.highlightDecoration ??
+          BoxDecoration(
+            color: Theme.of(context).splashColor,
+          );
+    } else {
+      return null;
+    }
   }
 }

--- a/lib/src/data_grid_theme.dart
+++ b/lib/src/data_grid_theme.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/material.dart';
+
+class DataGridThemeData {
+  /// Settings for sorting icons
+  final SortingIconSettings sortingIconSettings;
+
+  /// An optional decoration when a row is highlighted
+  /// Defaults to splash color
+  final BoxDecoration? rowHighlightDecoration;
+
+  /// An optional decoration when a row is selected
+  /// Defaults to primary color
+  final BoxDecoration? rowSelectedDecoration;
+
+  const DataGridThemeData({
+    /// Settings for sorting icons
+    this.sortingIconSettings = const SortingIconSettings(),
+
+    /// An optional decoration when a row is highlighted
+    /// Defaults to splash color
+    this.rowHighlightDecoration,
+
+    /// An optional decoration when a row is selected
+    /// Defaults to primary color
+    this.rowSelectedDecoration,
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is DataGridThemeData &&
+        runtimeType == other.runtimeType &&
+        sortingIconSettings == other.sortingIconSettings &&
+        rowHighlightDecoration == other.rowHighlightDecoration &&
+        rowSelectedDecoration == other.rowSelectedDecoration;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        sortingIconSettings,
+        rowHighlightDecoration,
+        rowSelectedDecoration,
+      );
+}
+
+class SortingIconSettings {
+  final IconData ascending;
+  final IconData descending;
+  final double size;
+  final Color? color;
+  final EdgeInsets padding;
+
+  const SortingIconSettings({
+    this.ascending = Icons.arrow_upward_rounded,
+    this.descending = Icons.arrow_downward_rounded,
+    this.size = 20,
+    this.color,
+    this.padding = const EdgeInsets.symmetric(horizontal: 4.0),
+  });
+
+  @override
+  bool operator ==(Object other) {
+    if (identical(this, other)) return true;
+
+    return other is SortingIconSettings &&
+        other.ascending == ascending &&
+        other.descending == descending &&
+        other.size == size &&
+        other.color == color &&
+        other.padding == padding;
+  }
+
+  @override
+  int get hashCode => Object.hash(
+        ascending,
+        descending,
+        size,
+        color,
+        padding,
+      );
+}


### PR DESCRIPTION
This PR adds a couple of features which are useful on desktop:
- Allow rows without headers
- Allow rows to be highlighed/selected

Also added a theme for the widget.

![Bildschirmfoto 2022-11-10 um 13 12 36](https://user-images.githubusercontent.com/13286425/201089138-c1785c69-7faa-4096-ae9a-4592d61f6e96.png)

Highlighting and selected works well when there is no row header. In the case of row header, this is disabled.