### PR TITLE
When hasRowHeader=false, reduce unnecessary rebuilds GridRows

### DIFF
--- a/lib/data_grid.dart
+++ b/lib/data_grid.dart
@@ -338,9 +338,10 @@ class _GridState extends State<Grid> {
                 rowsControllerX: rowsControllerX,
                 showHeader: !widget.hasRowHeader,
                 hoveringRowIndex: _hoveringRowIndex,
-                onHoverIndex: (index) => setState(
-                  () => _hoveringRowIndexRows = index,
-                ),
+                // only sync hover state if there are row headers, otherwise unnecessary rebuilds
+                onHoverIndex: (index) => widget.hasRowHeader
+                    ? setState(() => _hoveringRowIndexRows = index)
+                    : {},
                 highlightDecoration:
                     widget.dataGridThemeData.rowHighlightDecoration,
                 selectedRowIndex: widget.selectedRowIndex,


### PR DESCRIPTION
In #12 the option to not show row headers was introduced. In order to sync the hover state between `ListView` of row headers, and `ListView` of non-row headers, callbacks were introduced to rebuild `GridRowHeader` and `GridRows`.

Currently, using example app with 60 rows, the performance (using [performance](https://pub.dev/packages/performance)) on web is as follows:

![Bildschirmfoto 2022-11-25 um 10 53 01](https://user-images.githubusercontent.com/13286425/203956603-1e641677-7cd9-454e-a754-5d6b1f628f8c.png)

In fact, when `hasRowHeader=false`, `GridRows` does not need to rebuild as the row items themselves take care of their highlighted state, instead of rebuilding all rows on hover state change, we can save these rebuilds and performance improves:

![Bildschirmfoto 2022-11-25 um 10 51 39](https://user-images.githubusercontent.com/13286425/203956887-2fa0d3f5-5ce4-4c36-9339-1cd4e746b989.png)

Although this performance improvement is small for the example, on a more complicated website with more complicated data, I have seen very large improvements.